### PR TITLE
Adding next_page option to freebusy

### DIFF
--- a/src/methods/free-busy.js
+++ b/src/methods/free-busy.js
@@ -9,11 +9,11 @@ import rest from '../lib/rest-client';
 function freeBusy (options, callback) {
   const settings = {
     method: 'GET',
-    path: options.urls.api + '/v1/free_busy',
+    path: options.next_page || options.urls.api + '/v1/free_busy',
     headers: {
       Authorization: 'Bearer ' + options.access_token
     },
-    params: _.omit(options, 'access_token')
+    params: _.omit(options, 'access_token', 'next_page')
   };
   const result = rest(settings).fold(reach, 'entity');
 


### PR DESCRIPTION
FreeBusy also gets paginated https://www.cronofy.com/developers/api/#free-busy, so having  a next_page option that functions the same way ReadEvents does is useful.