### PR TITLE
remove const in favor of var

### DIFF
--- a/src/lib/rest-client.js
+++ b/src/lib/rest-client.js
@@ -5,7 +5,7 @@ var defaultRequest = require('rest/interceptor/defaultRequest');
 var mime = require('rest/interceptor/mime');
 var errorCode = require('rest/interceptor/errorCode');
 
-const client = rest
+var client = rest
   .wrap(defaultRequest, { headers: { 'User-Agent': 'Cronofy Node' } })
   .wrap(mime, { mime: 'application/json' })
   .wrap(errorCode);


### PR DESCRIPTION
With babel removed I believe this is the last change necessary to ensure this runs on ancient versions of Node still.