### PR TITLE
Clone arguments before adding default properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,22 @@ var omit = function (obj, props) {
   return res;
 };
 
+var clone = function (obj) {
+  if (!obj || typeof obj !== 'object') {
+    return obj;
+  }
+
+  var res = obj.constructor();
+
+  for (var prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      res[prop] = obj[prop];
+    }
+  }
+
+  return res;
+};
+
 cronofy.prototype._httpCall = function (method, path, options, callback, optionsToOmit) {
   var settings = {
     method: method,
@@ -91,12 +107,12 @@ cronofy.prototype._parseArguments = function (args, configDefaults) {
   var parsed = { options: {}, callback: null };
 
   if (args.length === 2) {
-    parsed.options = args[0];
+    parsed.options = clone(args[0]);
     parsed.callback = args[1];
   } else {
     switch (typeof args[0]) {
       case 'object':
-        parsed.options = args[0];
+        parsed.options = clone(args[0]);
         break;
       case 'function':
         parsed.callback = args[0];


### PR DESCRIPTION
Prevents the client library from modifying the options argument during function calls, to allow the options object to be reused on future function calls. Uses a clone of the options instead to enhance with any additional properties that the internal code needs.

Note this uses a simplified version of `clone` with only the features required for this fix to minimize the size of the library. 

Fixes #67 
