### PR TITLE
Allow config via data_center as well as dataCenter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,10 @@ var cronofy = function (config) {
 
   this.config = config;
 
+  var dc = config.data_center || config.dataCenter;
+
   this.urls = {
-    api: 'https://api' + (config.dataCenter ? '-' + config.dataCenter : '') + '.cronofy.com'
+    api: 'https://api' + (dc ? '-' + dc : '') + '.cronofy.com'
   };
 };
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -754,3 +754,36 @@ describe('Batch', function () {
     });
   });
 });
+
+describe('Data Center config property name normalization', function () {
+  it('allows data_center', function () {
+    var api = new Cronofy({
+      data_center: 'de'
+    });
+
+    expect(api.urls.api).to.eq('https://api-de.cronofy.com');
+  });
+
+  it('allows dataCenter', function () {
+    var api = new Cronofy({
+      dataCenter: 'de'
+    });
+
+    expect(api.urls.api).to.eq('https://api-de.cronofy.com');
+  });
+
+  it('prefers data_center', function () {
+    var api = new Cronofy({
+      data_center: 'de',
+      dataCenter: 'uk'
+    });
+
+    expect(api.urls.api).to.eq('https://api-de.cronofy.com');
+  });
+
+  it('uses US by default', function () {
+    var api = new Cronofy({});
+
+    expect(api.urls.api).to.eq('https://api.cronofy.com');
+  });
+});


### PR DESCRIPTION
There's a discrepancy with the current docs with respect to configuring the data center.

`data_center` is what we document, as well as being in keeping with the style of the other property names. However the implementation uses `dataCenter` currently, so this maintains support for that, while fixing the documented property name.