### PR TITLE
HMAC validation added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# cronofy-node [![Build Status](https://travis-ci.org/cronofy/cronofy-node.svg?branch=master)](https://travis-ci.org/cronofy/cronofy-node)
-
 A simple wrapper for the [Cronofy API](https://www.cronofy.com/developers/api/).
 
 ## Basic Usage

--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ cronofy.prototype.refreshAccessToken = function () {
   }), details.callback);
 };
 
-cronofy.prototype.hmacMatches = function () {
+cronofy.prototype.hmacValid = function () {
   var details = this._parseArguments(arguments, ['hmac', 'body', 'client_secret']);
   if (!details.options.hmac || details.options.hmac.length === 0) return false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ cronofy.prototype.refreshAccessToken = function () {
   }), details.callback);
 };
 
-cronofy.prototype.hmacMatch = function () {
+cronofy.prototype.hmacMatches = function () {
   var details = this._parseArguments(arguments, ['hmac', 'body', 'client_secret']);
   if (!details.options.hmac || details.options.hmac.length === 0) return false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 var request = require('request');
 var version = require('../package.json').version;
+var crypto = require('crypto');
 
 var tap = function (func) {
   return function (value) {
@@ -333,6 +334,16 @@ cronofy.prototype.refreshAccessToken = function () {
       details.callback(null, token);
     }
   }), details.callback);
+};
+
+cronofy.prototype.hmacMatch = function () {
+  var details = this._parseArguments(arguments, ['hmac', 'body', 'client_secret']);
+  if (!details.options.hmac || details.options.hmac.length === 0) return false;
+
+  var calculated = crypto.createHmac('sha256', details.options.client_secret).update(details.options.body).digest('base64');
+  var hmacList = details.options.hmac.split(',');
+
+  return hmacList.includes(calculated);
 };
 
 cronofy.prototype.requestAccessToken = function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -791,32 +791,32 @@ describe('Data Center config property name normalization', function () {
 
 describe('HMAC validation', function () {
   it('verifies the correct HMAC', () => {
-    const result = api.hmacMatches({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(true);
   });
 
   it('rejects the wrong HMAC', () => {
-    const result = api.hmacMatches({ hmac: 'something-else', body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: 'something-else', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('verifies the correct HMAC when one of the multiple HMACs splitted by "," match', () => {
-    const result = api.hmacMatches({ hmac: 'something-else,0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: 'something-else,0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(true);
   });
 
   it('rejects when multiple HMACs splitted by "," dont match', () => {
-    const result = api.hmacMatches({ hmac: 'something-else,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: 'something-else,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('rejects if HMAC is null', () => {
-    const result = api.hmacMatches({ hmac: null, body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: null, body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('rejects if HMAC is empty', () => {
-    const result = api.hmacMatches({ hmac: '', body: '{"example":"well-known"}' });
+    const result = api.hmacValid({ hmac: '', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -788,3 +788,35 @@ describe('Data Center config property name normalization', function () {
     expect(api.urls.api).to.eq('https://api.cronofy.com');
   });
 });
+
+describe('HMAC validation', function () {
+  it('verifies the correct HMAC', () => {
+    const result = api.hmacMatch({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(true);
+  });
+
+  it('rejects the wrong HMAC', () => {
+    const result = api.hmacMatch({ hmac: 'something-else', body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(false);
+  });
+
+  it('verifies the correct HMAC when one of the multiple HMACs splitted by "," match', () => {
+    const result = api.hmacMatch({ hmac: 'something-else,0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(true);
+  });
+
+  it('rejects when multiple HMACs splitted by "," dont match', () => {
+    const result = api.hmacMatch({ hmac: 'something-else,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(false);
+  });
+
+  it('rejects if HMAC is null', () => {
+    const result = api.hmacMatch({ hmac: null, body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(false);
+  });
+
+  it('rejects if HMAC is empty', () => {
+    const result = api.hmacMatch({ hmac: '', body: '{"example":"well-known"}' });
+    expect(result).to.deep.equal(false);
+  });
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -791,32 +791,32 @@ describe('Data Center config property name normalization', function () {
 
 describe('HMAC validation', function () {
   it('verifies the correct HMAC', () => {
-    const result = api.hmacMatch({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(true);
   });
 
   it('rejects the wrong HMAC', () => {
-    const result = api.hmacMatch({ hmac: 'something-else', body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: 'something-else', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('verifies the correct HMAC when one of the multiple HMACs splitted by "," match', () => {
-    const result = api.hmacMatch({ hmac: 'something-else,0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: 'something-else,0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(true);
   });
 
   it('rejects when multiple HMACs splitted by "," dont match', () => {
-    const result = api.hmacMatch({ hmac: 'something-else,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: 'something-else,38ArsN7+J/O8joGsgirVEdV16a/+eb+5QgHGIiuv4hk=', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('rejects if HMAC is null', () => {
-    const result = api.hmacMatch({ hmac: null, body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: null, body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 
   it('rejects if HMAC is empty', () => {
-    const result = api.hmacMatch({ hmac: '', body: '{"example":"well-known"}' });
+    const result = api.hmacMatches({ hmac: '', body: '{"example":"well-known"}' });
     expect(result).to.deep.equal(false);
   });
 });


### PR DESCRIPTION
New hmacMatch function that will verify that the proper HMAC has been passed. Users can pass multiple HMACS into a string, where those are separated by commas. If any of them match, then return true, otherwise false.
Added multiple tests to cover:
- Right HMAC being passed
- Wrong HMAC being passed
- Multiple HMACs being passed where only one of them is an entitled HMAC
- Multiple wrong HMACS
- NULL HMAC
- Empty HMAC