### PR TITLE
Fix read availability rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,9 @@ cronofy.prototype.upsertAvailabilityRule = function () {
 cronofy.prototype.readAvailabilityRule = function () {
   var details = this._parseArguments(arguments, ['access_token']);
 
-  return this._httpPost('/v1/availability_rules/' + details.options.availability_rule_id, details.options, details.callback);
+  var availabilityRuleId = details.options.availability_rule_id;
+  delete details.options.availability_rule_id;
+  return this._httpGet('/v1/availability_rules/' + availabilityRuleId, details.options, details.callback);
 };
 
 cronofy.prototype.deleteAvailabilityRule = function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -515,13 +515,14 @@ describe('Availability Rules', function () {
         'Content-Type': 'application/json'
       }
     })
-      .post('/v1/availability_rules/' + availabilityRuleId)
+      .get('/v1/availability_rules/' + availabilityRuleId)
       .reply(200, availabilityRuleResponse);
 
     api.readAvailabilityRule({ 'availability_rule_id': availabilityRuleId }, function (_, result) {
       expect(result).to.deep.equal(availabilityRuleResponse);
       done();
     });
+    nock.isDone();
   });
 
   it('can delete a rule', function (done) {


### PR DESCRIPTION
Fixes #78 - [Read Availability Rule](https://docs.cronofy.com/developers/api/scheduling/availability-rules/read-availability-rule/) has been incorrectly added as a HTTP POST instead of as a GET, which this PR corrects.