### PR TITLE
Parse `us` correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
-# [3.5.0]
+# [v3.5.1]
+
+* Normalize the value of `data_center`, including fallback when passed the value `us` [#83]
+
+# [v3.5.0]
 
 * Add `hmacValid` to verify the HMAC of push notifications [#77]
 * Fix `readAvailabilityRule` being a POST when it should be a GET [#78][#79]
 * Update dev dependencies and CI
 
 
-[3.5.0]: https://github.com/cronofy/cronofy-node/tag/v3.5.0
+[v3.5.1]: https://github.com/cronofy/cronofy-node/tag/v3.5.1
+[v3.5.0]: https://github.com/cronofy/cronofy-node/tag/v3.5.0
 
 [#77]: https://github.com/cronofy/cronofy-node/pull/77
 [#78]: https://github.com/cronofy/cronofy-node/issues/78
 [#79]: https://github.com/cronofy/cronofy-node/pull/79
+[#83]: https://github.com/cronofy/cronofy-node/pull/83

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cronofy",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "A simple wrapper for the Cronofy API",
     "main": "./src/index.js",
     "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,13 @@ var cronofy = function (config) {
 
   var dc = config.data_center || config.dataCenter;
 
+  if (dc) {
+    dc = dc.toLowerCase();
+    if (dc === 'us') {
+      dc = '';
+    }
+  }
+
   this.urls = {
     api: 'https://api' + (dc ? '-' + dc : '') + '.cronofy.com'
   };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -789,6 +789,38 @@ describe('Data Center config property name normalization', function () {
   });
 });
 
+describe('Data Center value normalization', function () {
+  it('defaults to the US datacenter', function () {
+    var api = new Cronofy({});
+
+    expect(api.urls.api).to.eq('https://api.cronofy.com');
+  });
+
+  it('appends the data_center to the URI', function () {
+    var api = new Cronofy({
+      data_center: 'de'
+    });
+
+    expect(api.urls.api).to.eq('https://api-de.cronofy.com');
+  });
+
+  it('appends the lowercased version of the data_center to the URI', function () {
+    var api = new Cronofy({
+      data_center: 'DE'
+    });
+
+    expect(api.urls.api).to.eq('https://api-de.cronofy.com');
+  });
+
+  it('does not append anything for the value "us"', function () {
+    var api = new Cronofy({
+      data_center: 'us'
+    });
+
+    expect(api.urls.api).to.eq('https://api.cronofy.com');
+  });
+});
+
 describe('HMAC validation', function () {
   it('verifies the correct HMAC', () => {
     const result = api.hmacValid({ hmac: '0g6bhIumRlRffctPXuASSl3u6AXOxnYRw+hiTp7IvTg=', body: '{"example":"well-known"}' });


### PR DESCRIPTION
* Lowercase DC values
* Correctly coerce the value `us` back to `api.cronofy.com`