### PR TITLE
Use axios instead of request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v3.7.0]
+
+* Use Axios to replace Request that is deprecated [#91]- thanks @gl-aagostino!
+
 # [v3.6.0]
 
 * Adds support for Update External events [#87]- thanks again @tia-svazquez!
@@ -17,7 +21,9 @@
 * Update dev dependencies and CI
 
 
+[v3.7.0]: https://github.com/cronofy/cronofy-node/tag/v3.7.0
 [v3.6.0]: https://github.com/cronofy/cronofy-node/tag/v3.6.0
+[v3.5.1]: https://github.com/cronofy/cronofy-node/tag/v3.5.2
 [v3.5.1]: https://github.com/cronofy/cronofy-node/tag/v3.5.1
 [v3.5.0]: https://github.com/cronofy/cronofy-node/tag/v3.5.0
 

--- a/package.json
+++ b/package.json
@@ -1,40 +1,35 @@
 {
-    "name": "cronofy",
-    "version": "3.6.0",
-    "description": "A simple wrapper for the Cronofy API",
-    "main": "./src/index.js",
-    "scripts": {
-        "prepublish": "npm test",
-        "test": "semistandard && mocha",
-        "start": "node ./src/index.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/cronofy/cronofy-node.git"
-    },
-    "keywords": [
-        "cronofy",
-        "api"
-    ],
-    "author": "Brett Warner <brett@warbrett.com> (www.warbrett.com)",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/cronofy/cronofy-node/issues"
-    },
-    "homepage": "https://github.com/cronofy/cronofy-node#readme",
-    "dependencies": {
-        "request": "^2.0.0"
-    },
-    "semistandard": {
-        "env": [
-            "mocha"
-        ]
-    },
-    "devDependencies": {
-        "chai": "^4.3.0",
-        "lodash": "^4.17.0",
-        "mocha": "^9.0.0",
-        "nock": "^13.0.0",
-        "semistandard": "^11.0.0"
-    }
+  "name": "cronofy",
+  "version": "3.7.0",
+  "description": "A simple wrapper for the Cronofy API",
+  "main": "./src/index.js",
+  "scripts": {
+    "prepublish": "npm test",
+    "test": "mocha",
+    "start": "node ./src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cronofy/cronofy-node-axios.git"
+  },
+  "keywords": [
+    "cronofy",
+    "api"
+  ],
+  "author": "Brett Warner <brett@warbrett.com> (www.warbrett.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cronofy/cronofy-node-axios/issues"
+  },
+  "homepage": "https://github.com/cronofy/cronofy-node-axios#readme",
+  "dependencies": {
+    "axios": "^0.27.0",
+    "qs": "^6.10.3"
+  },
+  "devDependencies": {
+    "chai": "^4.3.0",
+    "lodash": "^4.17.0",
+    "mocha": "^9.0.0",
+    "nock": "^13.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "cronofy",
   "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "cronofy",
-  "version": "3.7.0",
-  "description": "A simple wrapper for the Cronofy API",
-  "main": "./src/index.js",
-  "scripts": {
-      "prepublish": "npm test",
-      "test": "semistandard && mocha",
-      "start": "node ./src/index.js"
-  },
-  "repository": {
-      "type": "git",
-      "url": "git+https://github.com/cronofy/cronofy-node.git"
-  },
-  "keywords": [
-      "cronofy",
-      "api"
-  ],
-  "author": "Brett Warner <brett@warbrett.com> (www.warbrett.com)",
-  "license": "MIT",
-  "bugs": {
-      "url": "https://github.com/cronofy/cronofy-node/issues"
-  },
-  "homepage": "https://github.com/cronofy/cronofy-node#readme",
-  "dependencies": {
-      "axios": "^0.27.0",
-      "qs": "^6.10.3"
-  },
-  "semistandard": {
-      "env": [
-          "mocha"
-      ]
-  },
-  "devDependencies": {
-      "chai": "^4.3.0",
-      "lodash": "^4.17.0",
-      "mocha": "^9.0.0",
-      "nock": "^13.0.0",
-      "semistandard": "^11.0.0"
-  }
+    "name": "cronofy",
+    "version": "3.7.0",
+    "description": "A simple wrapper for the Cronofy API",
+    "main": "./src/index.js",
+    "scripts": {
+        "prepublish": "npm test",
+        "test": "semistandard && mocha",
+        "start": "node ./src/index.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/cronofy/cronofy-node.git"
+    },
+    "keywords": [
+        "cronofy",
+        "api"
+    ],
+    "author": "Brett Warner <brett@warbrett.com> (www.warbrett.com)",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/cronofy/cronofy-node/issues"
+    },
+    "homepage": "https://github.com/cronofy/cronofy-node#readme",
+    "dependencies": {
+        "axios": "^0.27.0",
+        "qs": "^6.10.3"
+    },
+    "semistandard": {
+        "env": [
+            "mocha"
+        ]
+    },
+    "devDependencies": {
+        "chai": "^4.3.0",
+        "lodash": "^4.17.0",
+        "mocha": "^9.0.0",
+        "nock": "^13.0.0",
+        "semistandard": "^11.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,35 +1,42 @@
+
 {
   "name": "cronofy",
   "version": "3.7.0",
   "description": "A simple wrapper for the Cronofy API",
   "main": "./src/index.js",
   "scripts": {
-    "prepublish": "npm test",
-    "test": "mocha",
-    "start": "node ./src/index.js"
+      "prepublish": "npm test",
+      "test": "semistandard && mocha",
+      "start": "node ./src/index.js"
   },
   "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cronofy/cronofy-node-axios.git"
+      "type": "git",
+      "url": "git+https://github.com/cronofy/cronofy-node.git"
   },
   "keywords": [
-    "cronofy",
-    "api"
+      "cronofy",
+      "api"
   ],
   "author": "Brett Warner <brett@warbrett.com> (www.warbrett.com)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cronofy/cronofy-node-axios/issues"
+      "url": "https://github.com/cronofy/cronofy-node/issues"
   },
-  "homepage": "https://github.com/cronofy/cronofy-node-axios#readme",
+  "homepage": "https://github.com/cronofy/cronofy-node#readme",
   "dependencies": {
-    "axios": "^0.27.0",
-    "qs": "^6.10.3"
+      "axios": "^0.27.0",
+      "qs": "^6.10.3"
+  },
+  "semistandard": {
+      "env": [
+          "mocha"
+      ]
   },
   "devDependencies": {
-    "chai": "^4.3.0",
-    "lodash": "^4.17.0",
-    "mocha": "^9.0.0",
-    "nock": "^13.0.0"
+      "chai": "^4.3.0",
+      "lodash": "^4.17.0",
+      "mocha": "^9.0.0",
+      "nock": "^13.0.0",
+      "semistandard": "^11.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@
 
 var version = require('../package.json').version;
 var crypto = require('crypto');
-const axios = require("axios").default;
-const qs = require("qs");
+const axios = require('axios').default;
+const qs = require('qs');
 
 var tap = function (func) {
   return function (value) {
@@ -72,28 +72,28 @@ cronofy.prototype._httpCall = function (
   optionsToOmit
 ) {
   let data;
-  if (method === "GET") {
-    let qsParams = omit(options, optionsToOmit || ["access_token"]);
-    let qsString = qs.stringify(qsParams, { arrayFormat: "brackets" });
+  if (method === 'GET') {
+    let qsParams = omit(options, optionsToOmit || ['access_token']);
+    let qsString = qs.stringify(qsParams, { arrayFormat: 'brackets' });
     if (qsString) {
       path += `?${qsString}`;
     }
   } else {
-    data = omit(options, optionsToOmit || ["access_token"]);
+    data = omit(options, optionsToOmit || ['access_token']);
   }
 
   return new Promise((resolve, reject) => {
     axios({
       data,
       headers: {
-        "Accept-Encoding": "gzip, deflate",
+        'Accept-Encoding': 'gzip, deflate',
         Authorization:
-          "Bearer " + (options.access_token || options.bearer_token),
-        "Content-Type": "application/json",
-        "User-Agent": "Cronofy Node - " + version,
+          'Bearer ' + (options.access_token || options.bearer_token),
+        'Content-Type': 'application/json',
+        'User-Agent': 'Cronofy Node - ' + version
       },
       method,
-      url: path,
+      url: path
     })
       .then((result) => {
         if (callback) {
@@ -112,7 +112,7 @@ cronofy.prototype._httpCall = function (
 
           err.error = {
             url: path,
-            entity: error.response.data,
+            entity: error.response.data
           };
 
           if (callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var request = require('request');
 var version = require('../package.json').version;
 var crypto = require('crypto');
+const axios = require("axios").default;
+const qs = require("qs");
 
 var tap = function (func) {
   return function (value) {
@@ -63,53 +64,70 @@ var clone = function (obj) {
   return res;
 };
 
-cronofy.prototype._httpCall = function (method, path, options, callback, optionsToOmit) {
-  var settings = {
-    method: method,
-    url: path,
-    gzip: true,
-    json: true,
-    headers: {
-      Authorization: 'Bearer ' + (options.access_token || options.bearer_token),
-      'Content-Type': 'application/json',
-      'User-Agent': 'Cronofy Node - ' + version
-    },
-    qsStringifyOptions: { arrayFormat: 'brackets' }
-  };
-
-  if (method === 'GET') {
-    settings['qs'] = omit(options, optionsToOmit || ['access_token']);
+cronofy.prototype._httpCall = function (
+  method,
+  path,
+  options,
+  callback,
+  optionsToOmit
+) {
+  let data;
+  if (method === "GET") {
+    let qsParams = omit(options, optionsToOmit || ["access_token"]);
+    let qsString = qs.stringify(qsParams, { arrayFormat: "brackets" });
+    if (qsString) {
+      path += `?${qsString}`;
+    }
   } else {
-    settings['body'] = omit(options, optionsToOmit || ['access_token']);
+    data = omit(options, optionsToOmit || ["access_token"]);
   }
 
-  return new Promise(function (resolve, reject) {
-    request(settings, function (error, result, body) {
-      if (error || result.statusCode >= 400) {
-        var err = new Error(JSON.stringify(body));
-
-        if (result && result.statusCode) {
-          err.statusCode = result.statusCode;
-        }
-
-        err.error = {
-          url: path,
-          entity: body
-        };
-
+  return new Promise((resolve, reject) => {
+    axios({
+      data,
+      headers: {
+        "Accept-Encoding": "gzip, deflate",
+        Authorization:
+          "Bearer " + (options.access_token || options.bearer_token),
+        "Content-Type": "application/json",
+        "User-Agent": "Cronofy Node - " + version,
+      },
+      method,
+      url: path,
+    })
+      .then((result) => {
         if (callback) {
-          callback(err);
+          callback(null, result.data);
         } else {
-          reject(err);
+          resolve(result.data);
         }
-      } else {
-        if (callback) {
-          callback(null, body);
+      })
+      .catch((error) => {
+        if (error.response && error.response.status >= 400) {
+          var err = new Error(JSON.stringify(error.response.data));
+
+          if (error.response && error.response.status) {
+            err.statusCode = error.response.status;
+          }
+
+          err.error = {
+            url: path,
+            entity: error.response.data,
+          };
+
+          if (callback) {
+            callback(err);
+          } else {
+            reject(err);
+          }
         } else {
-          resolve(body);
+          if (callback) {
+            callback(error);
+          } else {
+            reject(error);
+          }
         }
-      }
-    });
+      });
   });
 };
 


### PR DESCRIPTION
This PR replaces the deprecated `request` package with `axios`. This was primarily created so that this package can run on MongoDB Realm. It may have other related benefits as well.

All tests pass but semistandard throws a lot of warnings so it was circumvented during local testing. 