### PR TITLE
Remove reference to callback_url char limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           cache-name: cronofy-node
         with:

--- a/README.md
+++ b/README.md
@@ -182,10 +182,11 @@ Takes an optional callback, either returning a promise for, or calling the provi
 ### createNotificationChannel(options, callback)
 
 Takes options object and an optional callback, either returning a promise for, or calling the provided callback with an object with the new channel details.
+See full details in the [Create Notification Channel documentation](https://docs.cronofy.com/developers/api/push-notifications/create-channel/)
 
 #### Options Object
 
-- **callback_url** - required - The HTTP or HTTPS URL you wish to receive push notifications. Must not be longer than 128 characters and should be HTTPS.
+- **callback_url** - required - The HTTP or HTTPS URL you wish to receive push notifications. 
 
 ### deleteNotificationChannel(options, callback)
 


### PR DESCRIPTION
This limit no longer exists.

Also provide a link to the API documentation.